### PR TITLE
Devel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+terraform*
+.terraform*
+settings.json

--- a/README.md
+++ b/README.md
@@ -7,8 +7,10 @@ Terraform module that adds Cloud Compute Settings to an existing archive locatio
 
 ## Documentation
 
-Here are some resources to get you started! If you find any challenges from this project are not properly documented or are unclear, please raise an issueand let us know! This is a fun, safe environment - don't worry if you're a GitHub newbie!
+Here are some resources to get you started! If you find any challenges from this project are not properly documented or are unclear, please raise an issue and let us know! This is a fun, safe environment - don't worry if you're a GitHub newbie!
 
+- [Quick Start Guide](/docs/quick-start.md)
+- [Rubrik API Documentation](https://github.com/rubrikinc/api-documentation)
   - Only required to run the sample Rubrik command to update the Cloud Compute settings for the Archival Location.
 
 ### Usage
@@ -35,21 +37,23 @@ The following are the variables accepted by the module.
 
 There are a few services you'll need in order to get this project off the ground:
 
+- [Terraform](https://www.terraform.io/downloads.html) v0.15.4 or greater
+- [Rubrik Provider for Terraform](https://github.com/rubrikinc/rubrik-provider-for-terraform) - provides Terraform functions for Rubrik
   - Only required to run the sample Rubrik command to update the Cloud Compute settings for the Archival Location.
 
 ## How You Can Help
 
 We glady welcome contributions from the community. From updating the documentation to adding more functions for Python, all ideas are welcome. Thank you in advance for all of your issues, pull requests, and comments! :star:
 
-* [Contributing Guide](CONTRIBUTING.md)
-* [Code of Conduct](CODE_OF_CONDUCT.md)
+- [Contributing Guide](CONTRIBUTING.md)
+- [Code of Conduct](CODE_OF_CONDUCT.md)
 
 ## License
 
-* [MIT License](LICENSE)
+- [MIT License](LICENSE)
 
 ## About Rubrik Build
 
 We encourage all contributors to become members. We aim to grow an active, healthy community of contributors, reviewers, and code owners. Learn more in our [Welcome to the Rubrik Build Community](https://github.com/rubrikinc/welcome-to-rubrik-build) page.
 
-We'd  love to hear from you! Email us: build@rubrik.com 
+We'd love to hear from you! Email us: build@rubrik.com

--- a/README.md
+++ b/README.md
@@ -9,8 +9,7 @@ Terraform module that adds Cloud Compute Settings to an existing archive locatio
 
 Here are some resources to get you started! If you find any challenges from this project are not properly documented or are unclear, please raise an issueand let us know! This is a fun, safe environment - don't worry if you're a GitHub newbie!
 
-* [Quick Start Guide](/docs/quick-start.md)
-* [Rubrik API Documentation](https://github.com/rubrikinc/api-documentation)
+  - Only required to run the sample Rubrik command to update the Cloud Compute settings for the Archival Location.
 
 ### Usage
 
@@ -36,8 +35,7 @@ The following are the variables accepted by the module.
 
 There are a few services you'll need in order to get this project off the ground:
 
-* [Terraform](https://www.terraform.io/downloads.html) v0.10.3 or greater
-* [Rubrik Provider for Terraform](https://github.com/rubrikinc/rubrik-provider-for-terraform) - provides Terraform functions for Rubrik
+  - Only required to run the sample Rubrik command to update the Cloud Compute settings for the Archival Location.
 
 ## How You Can Help
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Terraform module that adds Cloud Compute Settings to an existing archive locatio
 
 - Create a new IAM Role with the correct permissions for CloudOn to use the AWS VMImport service.
 - Create a new Security Group to allow the Rubrik Cluster to talk to the Rubrik Storm instances.
+- Create S3 and KMS endpoint so that Rubrik Storm can keep data on the AWS network.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Terraform module that adds Cloud Compute Settings to an existing archive location. The following steps are completed by the module:
 
 - Create a new IAM Role with the correct permissions for CloudOn to use the AWS VMImport service.
+- Create a new Security Group to allow the Rubrik Cluster to talk to the Rubrik Storm instances.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 Terraform module that adds Cloud Compute Settings to an existing archive location. The following steps are completed by the module:
 
-* Create a new IAM Policy with the correct permissions for CloudOn and attach it to the specified user.
-* Configures Cloud Compute Settings on Rubrik cluster.
+- Create a new IAM Role with the correct permissions for CloudOn to use the AWS VMImport service.
 
 ## Documentation
 
@@ -32,6 +31,7 @@ module "rubrik_aws_cloudon" {
 The following are the variables accepted by the module.
 
 | aws_region                        | The AWS region to configure Rubrik Storm instances to run in.                                                    | string |                        |   yes    |
+| iam_vmimport_policy_name          | The name of the IAM Policy configured with the correct permissions for the VM Import service.                    | string |  rubrik-vmimport-role  |   yes    |
 
 ## Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ The following are the variables accepted by the module.
 | Name                              | Description                                                                                                      |  Type  |        Default         | Required |
 | --------------------------------- | ---------------------------------------------------------------------------------------------------------------- | :----: | :--------------------: | :------: |
 | aws_region                        | The AWS region to configure Rubrik Storm instances to run in.                                                    | string |                        |   yes    |
+| aws_vpc_security_group_name_storm | Name of the security group to create for Rubrik Storm instances to use.                                          | string | Rubrik Storm Instances |   yes    |
 | rubrik_cluster_cidr               | The CIDR range of the Rubrik Cluster. (Used to allow ingress to Storm from the Rubrik Cluster). Format x.x.x.x/y | string |                        |   yes    |
 | iam_user_name                     | The name of the IAM currently used for CloudOut to create.                                                       | string |                        |   yes    |
 | iam_policy_name                   | The name of the IAM Policy to be created with the correct CloudOut permissions.                                  | string |    rubrik-cloud-out    |    no    |

--- a/README.md
+++ b/README.md
@@ -30,15 +30,7 @@ module "rubrik_aws_cloudon" {
 
 The following are the variables accepted by the module.
 
-| Name                 | Description                                                                                                               |  Type  |      Default     | Required |
-|----------------------|---------------------------------------------------------------------------------------------------------------------------|:------:|:----------------:|:--------:|
-| archive_name         | The name of the existing Rubrik archive location in the Rubrik GUI.                                                                | string |                  |    yes   |
-| iam_user_name        | The name of the IAM currently used for CloudOut to create.                                                                                       | string |            |    yes    |
-| iam_policy_name      | The name of the IAM Policy to be created with the correct CloudOut permissions.                                              | string | rubrik-cloud-out |    no    |
-| vpc_id        | The id of the vpc used to run bolt.                                                                                             | string |  |    yes    |
-| subnet_id        | The id of the subnet used to run bolt.                                                                                             | string |  |    yes    |
-| security_group_id        | The id of the security group used to run bolt.                                                                                             | string |  |    yes    |
-| timeout        | Timeout value to be used when making Rubrik API call.                                                                                             | number | 60 |    no    |
+| aws_region                        | The AWS region to configure Rubrik Storm instances to run in.                                                    | string |                        |   yes    |
 
 ## Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,11 @@
 
 Terraform module that adds Cloud Compute Settings to an existing archive location. The following steps are completed by the module:
 
+- Create a new IAM Policy with the correct permissions for CloudOn and attach it to the specified user.
 - Create a new IAM Role with the correct permissions for CloudOn to use the AWS VMImport service.
 - Create a new Security Group to allow the Rubrik Cluster to talk to the Rubrik Storm instances.
 - Create S3 and KMS endpoint so that Rubrik Storm can keep data on the AWS network.
+- Configures Cloud Compute Settings on Rubrik cluster.
 
 ## Documentation
 
@@ -32,8 +34,17 @@ module "rubrik_aws_cloudon" {
 
 The following are the variables accepted by the module.
 
+| Name                              | Description                                                                                                      |  Type  |        Default         | Required |
+| --------------------------------- | ---------------------------------------------------------------------------------------------------------------- | :----: | :--------------------: | :------: |
 | aws_region                        | The AWS region to configure Rubrik Storm instances to run in.                                                    | string |                        |   yes    |
+| rubrik_cluster_cidr               | The CIDR range of the Rubrik Cluster. (Used to allow ingress to Storm from the Rubrik Cluster). Format x.x.x.x/y | string |                        |   yes    |
+| iam_user_name                     | The name of the IAM currently used for CloudOut to create.                                                       | string |                        |   yes    |
+| iam_policy_name                   | The name of the IAM Policy to be created with the correct CloudOut permissions.                                  | string |    rubrik-cloud-out    |    no    |
 | iam_vmimport_policy_name          | The name of the IAM Policy configured with the correct permissions for the VM Import service.                    | string |  rubrik-vmimport-role  |   yes    |
+| bucket_name                       | The name of the S3 bucket used for CloudOn from the Archival Location.                                           | string |                        |   yes    |
+| vpc_id                            | The id of the vpc used to run bolt.                                                                              | string |                        |   yes    |
+| subnet_id                         | The id of the subnet used to run bolt.                                                                           | string |                        |   yes    |
+| timeout                           | Timeout value to be used when making Rubrik API call.                                                            | number |           60           |    no    |
 
 ## Prerequisites
 

--- a/add-cloud-compute-settings.tf.example
+++ b/add-cloud-compute-settings.tf.example
@@ -1,0 +1,19 @@
+ # This code has be deprecated until the Terraform Rubrik Provider
+ # supports Terraform versions higher than v0.11
+
+################################
+#     Configure CloudOn        #
+################################
+
+resource "rubrik_aws_s3_cloudon" "cloudon" {
+  archive_name      = "${var.archive_name}"
+  vpc_id            = "${var.vpc_id}"
+  subnet_id         = "${var.subnet_id}"
+  security_group_id = "${var.security_group_id}"
+  timeout = "${var.timeout}"
+}
+
+# Move ths variable back to the variables.tf file when re-enabling this feature.
+variable "archive_name" {
+  description = "The name of the Rubrik archive location in the Rubrik GUI."
+}

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -1,10 +1,12 @@
-# Quick Start:  AWS S3 Rubrik CloudOn Terraform Module
+# Quick Start: AWS S3 Rubrik CloudOn Terraform Module
 
 Adds Cloud Compute Settings to an existing archive location. The following steps are completed by the module:
 
+- Create a new IAM Policy with the correct permissions for CloudOn and attach it to the specified user.
 - Create a new IAM Role with the correct permissions for CloudOn to use the AWS VMImport service.
 - Create a new Security Group to allow the Rubrik Cluster to talk to the Rubrik Storm instances.
 - Create S3 and KMS endpoints so that Rubrik Storm can keep data on the AWS network.
+- Configures Cloud Compute Settings on Rubrik cluster.
 
 Completing the steps detailed below will require that Terraform is installed and in your environment path, that you are running the instance from a \*nix shell (bash, zsh, etc).
 
@@ -45,7 +47,7 @@ The following are the variables accepted by the module.
 
 ## Running the Terraform Configuration
 
-This section outlines what is required to run the configuration defined above. 
+This section outlines what is required to run the configuration defined above.
 
 ### Prerequisites
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -30,9 +30,18 @@ You may also add additional variables, such as `iam_policy_name`, to overwrite t
 
 The following are the variables accepted by the module.
 
+| Name                              | Description                                                                                                      |  Type  |        Default         | Required |
+| --------------------------------- | ---------------------------------------------------------------------------------------------------------------- | :----: | :--------------------: | :------: |
 | aws_region                        | The AWS region to configure Rubrik Storm instances to run in.                                                    | string |                        |   yes    |
 | aws_vpc_security_group_name_storm | Name of the security group to create for Rubrik Storm instances to use.                                          | string | Rubrik Storm Instances |   yes    |
+| rubrik_cluster_cidr               | The CIDR range of the Rubrik Cluster. (Used to allow ingress to Storm from the Rubrik Cluster). Format x.x.x.x/y | string |                        |   yes    |
+| iam_user_name                     | The name of the IAM currently used for CloudOut to create.                                                       | string |                        |   yes    |
+| iam_policy_name                   | The name of the IAM Policy to be created with the correct CloudOut permissions.                                  | string |    rubrik-cloud-out    |    no    |
 | iam_vmimport_policy_name          | The name of the IAM Policy configured with the correct permissions for the VM Import service.                    | string |  rubrik-vmimport-role  |   yes    |
+| bucket_name                       | The name of the S3 bucket used for CloudOn from the Archival Location.                                           | string |                        |   yes    |
+| vpc_id                            | The id of the vpc used to run bolt.                                                                              | string |                        |   yes    |
+| subnet_id                         | The id of the subnet used to run bolt.                                                                           | string |                        |   yes    |
+| timeout                           | Timeout value to be used when making Rubrik API call.                                                            | number |           60           |    no    |
 
 ## Running the Terraform Configuration
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -4,6 +4,7 @@ Adds Cloud Compute Settings to an existing archive location. The following steps
 
 - Create a new IAM Role with the correct permissions for CloudOn to use the AWS VMImport service.
 - Create a new Security Group to allow the Rubrik Cluster to talk to the Rubrik Storm instances.
+- Create S3 and KMS endpoints so that Rubrik Storm can keep data on the AWS network.
 
 Completing the steps detailed below will require that Terraform is installed and in your environment path, that you are running the instance from a \*nix shell (bash, zsh, etc).
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -5,7 +5,7 @@ Adds Cloud Compute Settings to an existing archive location. The following steps
 * Create a new IAM Policy with the correct permissions for CloudOn and attach it to the specified user.
 * Configures Cloud Compute Settings on Rubrik cluster.
 
-Completing the steps detailed below will require that Terraform is installed and in your environment path, that you are running the instance from a *nix shell (bash, zsh, etc).
+Completing the steps detailed below will require that Terraform is installed and in your environment path, that you are running the instance from a \*nix shell (bash, zsh, etc).
 
 ## Configuration
 
@@ -37,6 +37,7 @@ This section outlines what is required to run the configuration defined above.
 
 ### Prerequisites
 
+- [Rubrik Provider for Terraform](https://github.com/rubrikinc/rubrik-provider-for-terraform) - provides Terraform functions for Rubrik
   - Only required to run the sample Rubrik command to update the Cloud Compute settings for the Archival Location.
 
 ### Initialize the Directory
@@ -70,6 +71,7 @@ If you ever set or change modules or backend configuration for Terraform,
 rerun this command to reinitialize your working directory. If you forget, other
 commands will detect it and remind you to do so if necessary.
 ```
+
 ### Planning
 
 Run `terraform plan` to get information about what will happen when we apply the configuration; this will test that everything is set up correctly.

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -3,6 +3,7 @@
 Adds Cloud Compute Settings to an existing archive location. The following steps are completed by the module:
 
 - Create a new IAM Role with the correct permissions for CloudOn to use the AWS VMImport service.
+- Create a new Security Group to allow the Rubrik Cluster to talk to the Rubrik Storm instances.
 
 Completing the steps detailed below will require that Terraform is installed and in your environment path, that you are running the instance from a \*nix shell (bash, zsh, etc).
 
@@ -29,6 +30,7 @@ You may also add additional variables, such as `iam_policy_name`, to overwrite t
 The following are the variables accepted by the module.
 
 | aws_region                        | The AWS region to configure Rubrik Storm instances to run in.                                                    | string |                        |   yes    |
+| aws_vpc_security_group_name_storm | Name of the security group to create for Rubrik Storm instances to use.                                          | string | Rubrik Storm Instances |   yes    |
 | iam_vmimport_policy_name          | The name of the IAM Policy configured with the correct permissions for the VM Import service.                    | string |  rubrik-vmimport-role  |   yes    |
 
 ## Running the Terraform Configuration

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -2,8 +2,7 @@
 
 Adds Cloud Compute Settings to an existing archive location. The following steps are completed by the module:
 
-* Create a new IAM Policy with the correct permissions for CloudOn and attach it to the specified user.
-* Configures Cloud Compute Settings on Rubrik cluster.
+- Create a new IAM Role with the correct permissions for CloudOn to use the AWS VMImport service.
 
 Completing the steps detailed below will require that Terraform is installed and in your environment path, that you are running the instance from a \*nix shell (bash, zsh, etc).
 
@@ -30,6 +29,7 @@ You may also add additional variables, such as `iam_policy_name`, to overwrite t
 The following are the variables accepted by the module.
 
 | aws_region                        | The AWS region to configure Rubrik Storm instances to run in.                                                    | string |                        |   yes    |
+| iam_vmimport_policy_name          | The name of the IAM Policy configured with the correct permissions for the VM Import service.                    | string |  rubrik-vmimport-role  |   yes    |
 
 ## Running the Terraform Configuration
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -37,8 +37,7 @@ This section outlines what is required to run the configuration defined above.
 
 ### Prerequisites
 
-* [Terraform](https://www.terraform.io/downloads.html) v0.10.3 or greater
-* [Rubrik Provider for Terraform](https://github.com/rubrikinc/rubrik-provider-for-terraform) - provides Terraform functions for Rubrik
+  - Only required to run the sample Rubrik command to update the Cloud Compute settings for the Archival Location.
 
 ### Initialize the Directory
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -29,15 +29,7 @@ You may also add additional variables, such as `iam_policy_name`, to overwrite t
 
 The following are the variables accepted by the module.
 
-| Name                 | Description                                                                                                               |  Type  |      Default     | Required |
-|----------------------|---------------------------------------------------------------------------------------------------------------------------|:------:|:----------------:|:--------:|
-| archive_name         | The name of the existing Rubrik archive location in the Rubrik GUI.                                                                | string |                  |    yes   |
-| iam_user_name        | The name of the IAM currently used for CloudOut to create.                                                                                       | string |            |    yes    |
-| iam_policy_name      | The name of the IAM Policy to be created with the correct CloudOut permissions.                                              | string | rubrik-cloud-out |    no    |
-| vpc_id        | The id of the vpc used to run bolt.                                                                                             | string |  |    yes    |
-| subnet_id        | The id of the subnet used to run bolt.                                                                                             | string |  |    yes    |
-| security_group_id        | The id of the security group used to run bolt.                                                                                             | string |  |    yes    |
-| timeout        | Timeout value to be used when making Rubrik API call.                                                                                             | number | 60 |    no    |
+| aws_region                        | The AWS region to configure Rubrik Storm instances to run in.                                                    | string |                        |   yes    |
 
 ## Running the Terraform Configuration
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -40,6 +40,7 @@ This section outlines what is required to run the configuration defined above.
 
 ### Prerequisites
 
+- [Terraform](https://www.terraform.io/downloads.html) v0.15.4 or greater
 - [Rubrik Provider for Terraform](https://github.com/rubrikinc/rubrik-provider-for-terraform) - provides Terraform functions for Rubrik
   - Only required to run the sample Rubrik command to update the Cloud Compute settings for the Archival Location.
 

--- a/main.tf
+++ b/main.tf
@@ -195,4 +195,30 @@ resource "aws_security_group" "rubrik-storm" {
     ipv6_cidr_blocks = ["::/0"]
   }
 }
+
+###################
+# AWS Endpoints   #
+###################
+
+# Note: It is Rubrik's and AWS' best proactice to use a S3 endpoint when accessing 
+# S3 data from EC2 instances. In cases where intenret access is not allowd 
+# from EC2 instances using a S3 endpoint is required. If a S3 endpoint already 
+# exists or is not desired this resource can be removed. 
+
+resource "aws_vpc_endpoint" "s3" {
+  vpc_id       = "${var.vpc_id}"
+  service_name = "com.amazonaws.${var.aws_region}.s3"
+}
+
+# NOTE: It is Rubrik's and AWS' best practice to use a KMS endpoint when accessing
+# KMS dat from EC2 instances. In cases where intenret access is not allowd 
+# from EC2 instances using a KMS endpoint is required. If a KMS endpoint already
+# exists or is not desired this resoruce can be removed.
+
+resource "aws_vpc_endpoint" "kms" {
+  vpc_id             = "${var.vpc_id}"
+  subnet_ids         = ["${var.subnet_id}"]
+  security_group_ids = ["${aws_security_group.rubrik-storm.id}"]
+  vpc_endpoint_type  = "Interface"
+  service_name       = "com.amazonaws.${var.aws_region}.kms"
 }

--- a/main.tf
+++ b/main.tf
@@ -146,11 +146,53 @@ resource "aws_iam_role_policy_attachment" "rubrik-vmimport" {
   policy_arn = aws_iam_policy.rubrik-vmimport.arn
 }
 
+#################################################
+# Security Group for the Rubrik Storm Instances #
+#################################################
 
-resource "rubrik_aws_s3_cloudon" "cloudon" {
-  archive_name      = "${var.archive_name}"
-  vpc_id            = "${var.vpc_id}"
-  subnet_id         = "${var.subnet_id}"
-  security_group_id = "${var.security_group_id}"
-  timeout = "${var.timeout}"
+resource "aws_security_group" "rubrik-storm" {
+  name        = "${var.aws_vpc_security_group_name_storm}"
+  description = "Allow Rubrik Cluster to talk to Rubrik Storm and intra Storm communication"
+  vpc_id      = "${var.vpc_id}"
+
+  ingress {
+    description      = "Intra Storm communication"
+    from_port        = 0
+    to_port          = 0
+    protocol         = "-1"
+    self             = true
+  }
+
+  ingress {
+    description      = "Cluster to Storm communication"
+    from_port        = 2002
+    to_port          = 2002
+    protocol         = "tcp"
+    cidr_blocks      = ["${var.rubrik_cluster_cidr}"]
+  }
+
+  ingress {
+    description      = "Cluster to Storm communication"
+    from_port        = 7785
+    to_port          = 7785
+    protocol         = "tcp"
+    cidr_blocks      = ["${var.rubrik_cluster_cidr}"]
+  }
+
+  ingress {
+    description      = "Cluster to Storm communication"
+    from_port        = 8077
+    to_port          = 8077
+    protocol         = "tcp"
+    cidr_blocks      = ["${var.rubrik_cluster_cidr}"]
+  }
+
+  egress {
+    from_port        = 0
+    to_port          = 0
+    protocol         = "-1"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+}
 }

--- a/main.tf
+++ b/main.tf
@@ -68,7 +68,9 @@ resource "aws_iam_policy" "cloud-on-permissions" {
               "ec2:DescribeImages",
               "ec2:DescribeVpcs",
               "ec2:CancelImportTask",
-              "ec2:DescribeConversionTasks"
+              "ec2:DescribeConversionTasks",
+              "iam:PutRolePolicy",
+              "iam:CreateRole"
             ],
             "Resource": "*"
         }

--- a/main.tf
+++ b/main.tf
@@ -11,8 +11,7 @@ provider "aws" {
 ##################
 
 resource "aws_iam_policy" "cloud-on-permissions" {
-  name = "${var.iam_policy_name}"
-
+  name   = "${var.iam_policy_name}"
   policy = <<EOF
 {
     "Version": "2012-10-17",

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,9 @@
-terraform {
-  required_version = ">= 0.10.3" # introduction of Local Values configuration language feature
+#############
+# Providers #
+#############
+
+provider "aws" {
+  region = "${var.aws_region}"
 }
 
 ##################

--- a/output.tf
+++ b/output.tf
@@ -1,0 +1,14 @@
+output "vpc_id" {
+    description = "ID of the VPC for the Rubrik Archival Location Cloud Compute settings."
+    value       = "${var.vpc_id}"
+}
+
+output "subnet_id" {
+    description = "The Subnet ID for the Rubrik Archival Location Cloud Compute settings."
+    value       = "${var.subnet_id}"
+}
+
+output "security_group_id" {
+    description = "ID of the Security Group ID for the Rubrik Archval Location Cloud Compute settings."
+    value       = "${aws_security_group.rubrik-storm.id}"
+}

--- a/provider.tf
+++ b/provider.tf
@@ -1,0 +1,11 @@
+#############################
+# Provider Configuration    #
+#############################
+terraform {
+  required_version = ">= 0.15.4"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+    }
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,6 +1,11 @@
 variable aws_region {
   description = "The AWS region to configure Rubrik Storm instances to run in"
 }
+
+variable "rubrik_cluster_cidr" {
+  description = "The CIDR range of the Rubrik Cluster. (Used to allow ingress to Storm from the Rubrik Cluster)"
+  default     = "10.0.0.0/24"
+}
 variable "iam_user_name" {
   description = "The name of the IAM currently used for CloudOut."
 }
@@ -8,10 +13,16 @@ variable "iam_policy_name" {
   description = "The name of the IAM Policy configured with the correct CloudOn permissions."
   default     = "rubrik-cloud-on"
 }
+
 variable "iam_vmimport_policy_name" {
   description = "The name of the IAM Policy configured with the correct permissions for the VM Import service."
   default     = "rubrik-vmimport-role"
 }
+
+variable "bucket_name" {
+  description = "The name of the S3 bucket used for CloudOn (this will be the same bucket as the CloudOut archival location uses)."
+}
+
 variable "vpc_id" {
   description = "The id of the vpc used to run bolt."
 }

--- a/variables.tf
+++ b/variables.tf
@@ -8,8 +8,9 @@ variable "iam_policy_name" {
   description = "The name of the IAM Policy configured with the correct CloudOn permissions."
   default     = "rubrik-cloud-on"
 }
-variable "archive_name" {
-  description = "The name of the Rubrik archive location in the Rubrik GUI."
+variable "iam_vmimport_policy_name" {
+  description = "The name of the IAM Policy configured with the correct permissions for the VM Import service."
+  default     = "rubrik-vmimport-role"
 }
 variable "vpc_id" {
   description = "The id of the vpc used to run bolt."

--- a/variables.tf
+++ b/variables.tf
@@ -1,5 +1,11 @@
+
 variable aws_region {
   description = "The AWS region to configure Rubrik Storm instances to run in"
+}
+
+variable "aws_vpc_security_group_name_storm" {
+  description = "Name of the security group to create for Rubrik Storm instances to use."
+  default     = "Rubrik Storm Instances"
 }
 
 variable "rubrik_cluster_cidr" {
@@ -28,9 +34,6 @@ variable "vpc_id" {
 }
 variable "subnet_id" {
   description = "The id of the subnet used to run bolt."
-}
-variable "security_group_id" {
-  description = "The id of the security group used to run bolt."
 }
 variable "timeout" {
   description = "Timeout value to be used when making Rubrik API call"

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,6 @@
+variable aws_region {
+  description = "The AWS region to configure Rubrik Storm instances to run in"
+}
 variable "iam_user_name" {
   description = "The name of the IAM currently used for CloudOut."
 }


### PR DESCRIPTION
# Description

- Tested with Terraform v0.15.4.
- Added Region Selection
- Deprecated the use of the Rubrik Provider until the Provider can be upgraded for a modern version of TF. 
- Added missing permissions for CloudOn.
- Create VMImport role
- Create Security Group for Storm
- Create S3 and KMS endpoints to follow best practices.
- Print the settings to use in the Cloud Compute Settings of Rubrik's Archival Location

## Related Issue

Fixes #4 
Deferred #3 

## Motivation and Context

Modernize the Terraform script and add missing components needed for a successful CloudOn deployment.

## How Has This Been Tested?

Used the Terraform script to create the CloudOn prerequisites. Successfully added the Cloud Compute Settings and ran the Storm validation test.

## Screenshots (if appropriate):

None

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!

- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **[CONTRIBUTION](https://github.com/rubrikinc/welcome-to-rubrik-build/blob/master/CONTRIBUTING.md)** document.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.